### PR TITLE
Fix stroke svg-export (fixed toSVG if object is async - fabric.Image)

### DIFF
--- a/test/svg_export/master.js
+++ b/test/svg_export/master.js
@@ -21,6 +21,10 @@
 
       function proceed() {
         __svgEl.innerHTML = canvas.toSVG();
+
+        __svgEl.onclick = function() {
+          console.log(canvas.toSVG());
+        };
       }
 
       function onShapeLoaded(objects, options) {
@@ -38,11 +42,7 @@
 
       eval(__code);
 
-      __svgEl.innerHTML = canvas.toSVG();
-
-      __svgEl.onclick = function() {
-        console.log(canvas.toSVG());
-      };
+      proceed();
 
     })(__all[__i]);
   }

--- a/test/svg_export/stroke.html
+++ b/test/svg_export/stroke.html
@@ -22,7 +22,7 @@ title: SVG Export (stroke)
   </div>
 </script>
 
-<pre class="test-source async">
+<pre class="test-source">
 var circle = new fabric.Circle({
   left: 100,
   top: 100,
@@ -35,7 +35,7 @@ var circle = new fabric.Circle({
 canvas.add(circle);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var circle = new fabric.Circle({
   left: 100,
   top: 100,
@@ -48,7 +48,7 @@ var circle = new fabric.Circle({
 canvas.add(circle);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var circle = new fabric.Circle({
   left: 100,
   top: 100,
@@ -61,7 +61,7 @@ var circle = new fabric.Circle({
 canvas.add(circle);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Rect({
   left: 150,
   top: 150,
@@ -75,7 +75,7 @@ var shape = new fabric.Rect({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Rect({
   left: 150,
   top: 150,
@@ -89,7 +89,7 @@ var shape = new fabric.Rect({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Rect({
   left: 150,
   top: 150,
@@ -103,7 +103,7 @@ var shape = new fabric.Rect({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Triangle({
   left: 150,
   top: 150,
@@ -117,7 +117,7 @@ var shape = new fabric.Triangle({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Triangle({
   left: 150,
   top: 150,
@@ -131,7 +131,7 @@ var shape = new fabric.Triangle({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Triangle({
   left: 150,
   top: 150,
@@ -145,7 +145,7 @@ var shape = new fabric.Triangle({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Line([10,10,100,100], {
   fill: '#ddd',
   stroke: '#333',
@@ -155,7 +155,7 @@ var shape = new fabric.Line([10,10,100,100], {
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Line([10,10,100,100], {
   fill: '#ddd',
   stroke: '#333',
@@ -165,7 +165,7 @@ var shape = new fabric.Line([10,10,100,100], {
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Line([10,10,100,100], {
   fill: '#ddd',
   stroke: '#333',
@@ -175,7 +175,7 @@ var shape = new fabric.Line([10,10,100,100], {
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Ellipse({
   left: 150,
   top: 150,
@@ -189,7 +189,7 @@ var shape = new fabric.Ellipse({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Ellipse({
   left: 150,
   top: 150,
@@ -203,7 +203,7 @@ var shape = new fabric.Ellipse({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Ellipse({
   left: 150,
   top: 150,
@@ -217,7 +217,7 @@ var shape = new fabric.Ellipse({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Polyline([
   {x:100,y:100},
   {x:150,y:150},
@@ -236,7 +236,7 @@ var shape = new fabric.Polyline([
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Polyline([
   {x:100,y:100},
   {x:150,y:150},
@@ -255,7 +255,7 @@ var shape = new fabric.Polyline([
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Polyline([
   {x:100,y:100},
   {x:150,y:150},
@@ -274,7 +274,7 @@ var shape = new fabric.Polyline([
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Path('M 0 0 L 300 100 L 200 300 z', {
   left: 150,
   top: 150,
@@ -288,7 +288,7 @@ var shape = new fabric.Path('M 0 0 L 300 100 L 200 300 z', {
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Path('M 0 0 L 300 100 L 200 300 z', {
   left: 150,
   top: 150,
@@ -302,7 +302,7 @@ var shape = new fabric.Path('M 0 0 L 300 100 L 200 300 z', {
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Path('M 0 0 L 300 100 L 200 300 z', {
   left: 150,
   top: 150,
@@ -327,6 +327,7 @@ canvas.add(shape);
       top: 150
     });
     canvas.add(img);
+    proceed();
   });
 </pre>
 
@@ -341,6 +342,7 @@ canvas.add(shape);
       top: 150
     });
     canvas.add(img);
+    proceed();
   });
 </pre>
 
@@ -355,10 +357,11 @@ canvas.add(shape);
       top: 150
     });
     canvas.add(img);
+    proceed();
   });
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Rect({
   left: 150,
   top: 150,
@@ -372,7 +375,7 @@ var shape = new fabric.Rect({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Rect({
   left: 150,
   top: 150,
@@ -386,7 +389,7 @@ var shape = new fabric.Rect({
 canvas.add(shape);
 </pre>
 
-<pre class="test-source async">
+<pre class="test-source">
 var shape = new fabric.Rect({
   left: 150,
   top: 150,


### PR DESCRIPTION
The tests with fabric.Image didn't work - call proceed after image is loaded and added to canvas.
