### PR TITLE
Add fabric.Polygon stroke example + Bugfix IE inline svg

### DIFF
--- a/test/svg_export/master.css
+++ b/test/svg_export/master.css
@@ -1,10 +1,11 @@
-pre { width: 450px; max-width: 500px; padding: 10px; margin: 0 30px 0 0; background: #444; color: #eee; font-size: 11px; 
+svg { overflow: hidden; }
+pre { width: 450px; max-width: 500px; padding: 10px; margin: 0 30px 0 0; background: #444; color: #eee; font-size: 11px;
     word-wrap: break-word; white-space: -moz-pre-wrap; white-space: pre-wrap; }
 .column { float: left; min-width: 300px; margin-right: 10px; }
 .column p { margin: 0 0 5px 0; padding: 0; }
 .lower-canvas, .svg { margin-bottom: 10px; border: 1px solid #eee; background: #fff; }
 .svg { width: 300px; height: 300px; }
-.test { overflow: hidden; background: #eee; margin-bottom: 20px; display: inline-block; float: left; 
+.test { overflow: hidden; background: #eee; margin-bottom: 20px; display: inline-block; float: left;
   padding: 10px; box-shadow: 1px 1px 1px rgba(0,0,0,0.4) }
 .test-source { display: none }
 .note { background: #ffc; padding: 3px; box-shadow: 0 0 1px rgba(0,0,0,0.3); display: inline-block; }

--- a/test/svg_export/stroke.html
+++ b/test/svg_export/stroke.html
@@ -275,6 +275,63 @@ canvas.add(shape);
 </pre>
 
 <pre class="test-source">
+var shape = new fabric.Polygon([
+  {x:100,y:100},
+  {x:150,y:150},
+  {x:200,y:250},
+  {x:220,y:100},
+  {x:300,y:80},
+  {x:80,y:20}
+], {
+  left: 150,
+  top: 150,
+  fill: '#ddd',
+  stroke: '#333',
+  strokeWidth: 3,
+  strokeDashArray: [5, 10]
+});
+canvas.add(shape);
+</pre>
+
+<pre class="test-source">
+var shape = new fabric.Polygon([
+  {x:100,y:100},
+  {x:150,y:150},
+  {x:200,y:250},
+  {x:220,y:100},
+  {x:300,y:80},
+  {x:80,y:20}
+], {
+  left: 150,
+  top: 150,
+  fill: '#ddd',
+  stroke: '#333',
+  strokeWidth: 3,
+  strokeDashArray: [10, 5]
+});
+canvas.add(shape);
+</pre>
+
+<pre class="test-source">
+var shape = new fabric.Polygon([
+  {x:100,y:100},
+  {x:150,y:150},
+  {x:200,y:250},
+  {x:220,y:100},
+  {x:300,y:80},
+  {x:80,y:20}
+], {
+  left: 150,
+  top: 150,
+  fill: '#ddd',
+  stroke: '#333',
+  strokeWidth: 3,
+  strokeDashArray: [5, 20, 20, 5]
+});
+canvas.add(shape);
+</pre>
+
+<pre class="test-source">
 var shape = new fabric.Path('M 0 0 L 300 100 L 200 300 z', {
   left: 150,
   top: 150,


### PR DESCRIPTION
- Add fabric.Polygon stroke example
- Fix Internet Explorer inline svg overflow bug
