### PR TITLE
Fix jsdoc3 "jump to line" for certain browser (chrome 28, IE, opera 15).

### DIFF
--- a/docs/scripts/linenumber.js
+++ b/docs/scripts/linenumber.js
@@ -9,7 +9,7 @@
         numbered = source.innerHTML.split('\n');
         numbered = numbered.map(function(item) {
             counter++;
-            return '<span id="line' + counter + '"></span>' + item;
+            return '<span id="line' + counter + '" class="line"></span>' + item;
         });
 
         source.innerHTML = numbered.join('\n');

--- a/docs/styles/jsdoc-default.css
+++ b/docs/styles/jsdoc-default.css
@@ -240,6 +240,11 @@ h6
 	border-left: 3px #ddd solid;
 }
 
+.prettyprint code span.line
+ {
+   display: inline-block;
+ }
+
 .params, .props
 {
 	border-spacing: 0;


### PR DESCRIPTION
Add fix from https://github.com/jsdoc3/jsdoc/commit/09b489a792416234e1d15bcd673370e54eba1b9d
