### PR TITLE
Update itext.html with proper UTF-8 charset in data uri

### DIFF
--- a/test/misc/itext.html
+++ b/test/misc/itext.html
@@ -129,7 +129,7 @@ title: IText tests
 
       linkEl.onclick = (function(container) {
         return function() {
-          window.open('data:image/svg+xml;utf-8,' +
+          window.open('data:image/svg+xml;charset=utf-8,' +
             encodeURIComponent(container.canvas.toSVG()));
 
           return false;


### PR DESCRIPTION
This was causing the unicode example on http://fabricjs.com/test/misc/itext.html to appear to output incorrect SVG when it wasn't.
