### PR TITLE
Remove localhost reference in Custom build page

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -43,7 +43,7 @@ title: Custom Fabric build
   <li>
     <input type="checkbox" id="easing">
     <label for="easing">Easing</label><br>
-    <p>Adds support for <a href="http://localhost:4000/animation-easing/">animation easing</a> functions</p>
+    <p>Adds support for <a href="/animation-easing/">animation easing</a> functions</p>
   </li>
   <li>
     <input type="checkbox" id="parser">


### PR DESCRIPTION
Stumbled upon that small issue when getting a custom build from the website
