### PR TITLE
Group centering

### DIFF
--- a/posts/_posts/2012-8-12-fabric-intro-part-3.html
+++ b/posts/_posts/2012-8-12-fabric-intro-part-3.html
@@ -33,7 +33,9 @@ var text = new fabric.Text('hello world', {
 var circle = new fabric.Circle({
   radius: 100,
   fill: '#eef',
-  scaleY: 0.5
+  scaleY: 0.5,
+  originX: 'center',
+  originY: 'center'
 });
 
 var group = new fabric.Group([ text, circle ], {
@@ -120,11 +122,13 @@ fabric.Image.fromURL('/assets/pug.jpg', function(img) {
 
 <p>You can add/remove objects from group in 2 ways — with update of group dimensions/position and without.</p>
 
-<p>To add rectangle at the center of a group (left=0, top=0):</p>
+<p>To add rectangle at the center of a group:</p>
 
 <pre>
 group.add(new fabric.Rect({
   ...
+  originX: 'center',
+  originY: 'center'
 }));
 </pre>
 
@@ -134,7 +138,9 @@ group.add(new fabric.Rect({
 group.add(new fabric.Rect({
   ...
   left: 100,
-  top: 100
+  top: 100,
+  originX: 'center',
+  originY: 'center'
 }));
 </pre>
 
@@ -144,7 +150,9 @@ group.add(new fabric.Rect({
 group.addWithUpdate(new fabric.Rect({
   ...
   left: group.getLeft(),
-  top: group.getTop()
+  top: group.getTop(),
+  originX: 'center',
+  originY: 'center'
 }));
 </pre>
 
@@ -154,7 +162,9 @@ group.addWithUpdate(new fabric.Rect({
 group.addWithUpdate(new fabric.Rect({
   ...
   left: group.getLeft() + 100,
-  top: group.getTop() + 100
+  top: group.getTop() + 100,
+  originX: 'center',
+  originY: 'center'
 }));
 </pre>
 


### PR DESCRIPTION
Post-1.4.0, the default behavior for group members is to be relative to top-left, not the group's center. Update the examples to show the explicit centering.
