### PR TITLE
Fix #5580

### DIFF
--- a/posts/_posts/2012-7-25-fabric-intro-part-2.html
+++ b/posts/_posts/2012-7-25-fabric-intro-part-2.html
@@ -149,8 +149,8 @@ fabric.Image.filters.Redify = fabric.util.createClass(fabric.Image.filters.BaseF
     'varying vec2 vTexCoord;\n' +
     'void main() {\n' +
       'vec4 color = texture2D(uTexture, vTexCoord);\n' +
-      'color.g = 0;\n' +
-      'color.b = 0;\n' +
+      'color.g = 0.0;\n' +
+      'color.b = 0.0;\n' +
       'gl_FragColor = color;\n' +
     '}',
 


### PR DESCRIPTION
The docs contain a typo that prevents the example fragment from compiling