### PR TITLE
bugfix: Uncaught TypeError

### DIFF
--- a/posts/demos/_posts/2020-2-15-custom-control-render.md
+++ b/posts/demos/_posts/2020-2-15-custom-control-render.md
@@ -88,7 +88,8 @@ We build a function following the mouseUpHandler signature and we use there `can
 
   Add();
 
-  function deleteObject(eventData, target) {
+ function deleteObject(eventData, wrapped) {
+                var target = wrapped.target
 		var canvas = target.canvas;
 		    canvas.remove(target);
         canvas.requestRenderAll();
@@ -202,13 +203,15 @@ For the clone functionality we will simply do
 
   Add();
 
-  function deleteObject(eventData, target) {
+  function deleteObject(eventData, wrapped) {
+                var target = wrapped.target
 		var canvas = target.canvas;
 		    canvas.remove(target);
         canvas.requestRenderAll();
 	}
 
-  function cloneObject(eventData, target) {
+  function cloneObject(eventData, wrapped) {
+    var target = wrapped.target
     var canvas = target.canvas;
     target.clone(function(cloned) {
       cloned.left += 10;


### PR DESCRIPTION
In posts/demos/_posts/2020-2-15-custom-control-render.md
deleteObject() and cloneObject() methods are trying to access target.canvas which is undefined. It should be target.target.canvas.
Tested on latest Firefox and Chrome on Windows.