### PR TITLE
Update itext_key_behavior.mixin.js

### DIFF
--- a/build/files/src/mixins/itext_key_behavior.mixin.js
+++ b/build/files/src/mixins/itext_key_behavior.mixin.js
@@ -16,7 +16,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     // https://bugs.chromium.org/p/chromium/issues/detail?id=870966
     this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + style.top +
     '; left: ' + style.left + '; z-index: -999; opacity: 0; width: 1px; height: 1px; font-size: 1px;' +
-    ' paddingｰtop: ' + style.fontSize + ';';
+    ' padding-top: ' + style.fontSize + ';';
 
     if (this.hiddenTextareaContainer) {
       this.hiddenTextareaContainer.appendChild(this.hiddenTextarea);


### PR DESCRIPTION
Non ASCII character on line 19. Hyphen in padding-top was non standard