### PR TITLE
fix: add subscript function on demo

### DIFF
--- a/posts/demos/_posts/2018-03-03-super-sub-script.html
+++ b/posts/demos/_posts/2018-03-03-super-sub-script.html
@@ -39,6 +39,13 @@ function superScript() {
 	canvas.requestRenderAll();
 }
 
+function subScript() {
+	var active = canvas.getActiveObject();
+	if (!active) return;
+	active.setSubscript();
+	canvas.requestRenderAll();
+}
+
 var canvas = this.__canvas = new fabric.Canvas('c');
 // create a rectangle object
 var itext = new fabric.IText('This is a IText object', {


### PR DESCRIPTION
Currently, the subscript function is missing, so clicking the "Set subscript on selection" button produces no effect.
This contribution fixes this issue.