### PR TITLE
Fix typo: "instantiation" -> "instantiating"

### DIFF
--- a/posts/_posts/2012-6-25-fabric-intro-part-1.html
+++ b/posts/_posts/2012-6-25-fabric-intro-part-1.html
@@ -412,7 +412,7 @@ canvas.add(path);
 
   <p><img src="/article_assets/10.png"></p>
 
-  <p>We're instantiation <code>fabric.Path</code> object, passing it a string of path instructions. While it looks cryptic, it's actually easy to understand. &#8220;M&#8221; represents &#8220;move&#8221; command, and tells that invisible pen to move to 0, 0 point. &#8220;L&#8221; stands for &#8220;line&#8221; and makes pen draw a line to 200, 100 point. Then, another &#8220;L&#8221; creates a line to 170, 200. Lastly, &#8220;z&#8221; tells forces drawing pen to close current path and finalize the shape. As a result, we get a triangular shape.</p>
+  <p>We're instantiating <code>fabric.Path</code> object, passing it a string of path instructions. While it looks cryptic, it's actually easy to understand. &#8220;M&#8221; represents &#8220;move&#8221; command, and tells that invisible pen to move to 0, 0 point. &#8220;L&#8221; stands for &#8220;line&#8221; and makes pen draw a line to 200, 100 point. Then, another &#8220;L&#8221; creates a line to 170, 200. Lastly, &#8220;z&#8221; tells forces drawing pen to close current path and finalize the shape. As a result, we get a triangular shape.</p>
 
   <p>Since <code>fabric.Path</code> is just like any other object in Fabric, we were also able to change some of its properties. But we can modify it even more:</p>
 


### PR DESCRIPTION
"We're instantiation fabric.Path object" -> "We're instantiating fabric.Path object"