### PR TITLE
fix(demos): fix video-element webcam moveTo error on Fabric 6

### DIFF
--- a/posts/demos/_posts/2014-10-16-video-element.html
+++ b/posts/demos/_posts/2014-10-16-video-element.html
@@ -69,7 +69,13 @@ navigator.mediaDevices.getUserMedia({video: true})
     webcamEl.srcObject = localMediaStream;
 
     canvas.add(webcam);
-    webcam.moveTo(0); // move webcam element to back of zIndex stack
+    // move webcam element to back of zIndex stack
+    // (fabric.Object#moveTo was removed in Fabric 6 in favor of canvas methods)
+    if (typeof canvas.sendObjectToBack === 'function') {
+      canvas.sendObjectToBack(webcam); // Fabric 6+
+    } else {
+      webcam.moveTo(0);                // Fabric 5
+    }
     webcam.getElement().play();
   }).catch(function getWebcamNotAllowed(e) {
   // block will be hit if user selects "no" for browser "allow webcam access" prompt


### PR DESCRIPTION
## Problem
The video-element demo throws `TypeError: webcam.moveTo is not a function`
after the user grants camera permission, leaving the webcam preview black.

`fabric.Object#moveTo(index)` was removed in Fabric 6 (per-object stacking
moved to canvas methods). The demo runs under two Fabric versions:
- **v5.2.1** on the live demo page (`_layouts/demo.html` loads `lib/fabric.js`) — `moveTo` works.
- **v6** via the "Open in CodePen" button (`_includes/codepen.html` loads
  `fabric@latest`) and the new fabricjs.com — `moveTo` throws.

## Fix
Feature-detect the API so the demo works under both versions: use
`canvas.sendObjectToBack(webcam)` when available (Fabric 6+), otherwise fall
back to `webcam.moveTo(0)` (Fabric 5). `sendObjectToBack` is the exact v6
equivalent of `moveTo(0)`.

Only `posts/demos/_posts/2014-10-16-video-element.html` is touched.

## Testing
- Local (`jekyll serve`, v5.2.1): open `/demos/video-element/`, grant camera →
  no console error, webcam renders behind the sample video.
- CodePen (v6 via unpkg): same demo, grant camera → no `moveTo` TypeError.

Signed-off-by: Kiran Parajuli <39373750+kiranparajuli589@users.noreply.github.com>
